### PR TITLE
[fix]: 메인 페이지 내 신규 행사 및 신규 팀원 모집 개별 컴포넌트 내부 Link 태그 href 속성 추가 (#16)

### DIFF
--- a/app/components/Event.tsx
+++ b/app/components/Event.tsx
@@ -1,11 +1,15 @@
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 import React from 'react';
 
 export default function Event() {
   return (
     <div className='relative flex flex-col gap-4 bg-[#f7f7f7] p-3 group'>
       <p className='font-bold'>
-        <Link href='/' className='hover:underline'>
+        <Link
+          href='/events/645f82d1dfc11e0020d07253'
+          className='hover:underline'
+        >
           2023학년도 졸업작품전시회(캡스톤디자인전시회)일정 및 작품소개서 제출
           안내(~10/17)
         </Link>

--- a/app/components/FindMember.tsx
+++ b/app/components/FindMember.tsx
@@ -5,7 +5,10 @@ export default function FindMember() {
   return (
     <div className='relative flex flex-col gap-4 bg-[#f7f7f7] p-3 group'>
       <p className='font-bold'>
-        <Link href='/' className='hover:underline'>
+        <Link
+          href='/find-members/645f82d1dfc11e0020d07253'
+          className='hover:underline'
+        >
           데이터베이스시스템 팀 프로젝트 팀원 모집
         </Link>
       </p>


### PR DESCRIPTION
## 👀 이슈

resolve #16 

## 📌 개요

현재 메인 페이지 내 `신규 행사` 및 `신규 팀원 모집` 개별 컴포넌트 내부에서
사용 중인 **`Link`** 태그에 `href` 속성을 추가하였습니다.

## 👩‍💻 작업 사항

- 메인 페이지 내 `신규 행사` 개별 컴포넌트 내부 **`Link`** 태그 수정
- 메인 페이지 내 `신규 팀원 모집` 개별 컴포넌트 내부 **`Link`** 태그 수정

## ✅ 참고 사항

없습니다