### PR TITLE
[feat]: 페이지 상단 이동 버튼 추가 (#22)

### DIFF
--- a/app/components/ScrollToTopButton.tsx
+++ b/app/components/ScrollToTopButton.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import React from 'react';
+import ScrollToTop from 'react-scroll-up';
+
+export default function ScrollToBottomTop() {
+  return (
+    <div>
+      <ScrollToTop
+        showUnder={160}
+        style={{
+          marginRight: '5rem',
+          marginBottom: '7rem',
+          padding: '0.4rem',
+          backgroundColor: 'gray',
+          borderRadius: '10rem',
+        }}
+      >
+        <svg
+          xmlns='http://www.w3.org/2000/svg'
+          height='35'
+          viewBox='0 -960 960 960'
+          width='35'
+          fill='white'
+        >
+          <path d='M440-160v-487L216-423l-56-57 320-320 320 320-56 57-224-224v487h-80Z' />
+        </svg>
+      </ScrollToTop>
+    </div>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import Footer from './components/Footer';
 import Navbar from './components/Navbar';
+import ScrollToBottomTop from './components/ScrollToTopButton';
 import './globals.css';
 import ReduxProvider from './redux/provider';
 
@@ -22,6 +23,7 @@ export default function RootLayout({
         <ReduxProvider>
           <Navbar />
           <main className='w-full mx-auto pt-20 mb-14'>{children}</main>
+          <ScrollToBottomTop />
           <Footer />
         </ReduxProvider>
       </body>

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "next-redux-wrapper": "^8.1.0",
     "react": "latest",
     "react-dom": "latest",
-    "react-redux": "^8.1.3"
+    "react-redux": "^8.1.3",
+    "react-scroll-up": "^1.4.0"
   },
   "devDependencies": {
     "@types/node": "latest",

--- a/yarn.lock
+++ b/yarn.lock
@@ -848,6 +848,18 @@ dequal@^2.0.0, dequal@^2.0.3:
   resolved "https://registry.yarnpkg.com/dequal/-/dequal-2.0.3.tgz#2644214f1997d39ed0ee0ece72335490a7ac67be"
   integrity sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==
 
+detect-it@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/detect-it/-/detect-it-4.0.1.tgz#3f8de6b8330f5086270571251bedf10aec049e18"
+  integrity sha512-dg5YBTJYvogK1+dA2mBUDKzOWfYZtHVba89SyZUhc4+e3i2tzgjANFg5lDRCd3UOtRcw00vUTMK8LELcMdicug==
+
+detect-passive-events@^2.0.2:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/detect-passive-events/-/detect-passive-events-2.0.3.tgz#1f75ebf80660a66c615d8be23c3241cdda6977e0"
+  integrity sha512-QN/1X65Axis6a9D8qg8Py9cwY/fkWAmAH/edTbmLMcv4m5dboLJ7LcAi8CfaCON2tjk904KwKX/HTdsHC6yeRg==
+  dependencies:
+    detect-it "^4.0.1"
+
 didyoumean@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/didyoumean/-/didyoumean-1.2.2.tgz#989346ffe9e839b4555ecf5666edea0d3e8ad037"
@@ -2852,7 +2864,7 @@ prelude-ls@^1.2.1:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
 
-prop-types@^15.0.0, prop-types@^15.8.1:
+prop-types@^15.0.0, prop-types@^15.5.8, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -2940,6 +2952,16 @@ react-redux@^8.1.3:
     hoist-non-react-statics "^3.3.2"
     react-is "^18.0.0"
     use-sync-external-store "^1.0.0"
+
+react-scroll-up@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/react-scroll-up/-/react-scroll-up-1.4.0.tgz#2d17ce1b9a92614e5ac6eb63fcb1c07136a2fb48"
+  integrity sha512-UppnsEams+0bBoSSasSHveYNyOwkoOrFm8jKWvU5SsNSBKji4LL/lF6cdUSHKNdtKaD7wc/d3576Qc+IjNoBxw==
+  dependencies:
+    detect-passive-events "^2.0.2"
+    object-assign "^4.0.1"
+    prop-types "^15.5.8"
+    tween-functions "^1.1.0"
 
 react@latest:
   version "18.2.0"
@@ -3497,6 +3519,11 @@ tslib@^2.0.0, tslib@^2.4.0:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
   integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
+
+tween-functions@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/tween-functions/-/tween-functions-1.2.0.tgz#1ae3a50e7c60bb3def774eac707acbca73bbc3ff"
+  integrity sha512-PZBtLYcCLtEcjL14Fzb1gSxPBeL7nWvGhO5ZFPGqziCcr8uvHp0NDmdjBchp6KHL+tExcg0m3NISmKxhU394dA==
 
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"


### PR DESCRIPTION
## 👀 이슈

resolve #22 

## 📌 개요

페이지 하단으로 스크롤이 일정 수준 일어났을 때 다시 웹 페이지
상단으로 화면을 빠르게 이동시킬 수 있도록 하고자 `페이지 상단 이동 버튼`을
추가하였습니다.

## 👩‍💻 작업 사항

- 홈페이지 우측 하단에 `페이지 상단 이동 버튼` 추가

## ✅ 참고 사항

- `페이지 상단 이동 버튼` UI

https://github.com/bae-sisi/bss-client/assets/56868605/0123e52e-156f-432a-8011-0db7ee2ee9d7