### PR TITLE
[feat]: `마이페이지` 내 `이메일/비밀번호/이름 변경` 기능 추가 (#26)

### DIFF
--- a/app/mypage/components/modifyEmailModal.tsx
+++ b/app/mypage/components/modifyEmailModal.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { Modal } from 'flowbite-react';
+
+interface ModifyEmailModalProps {
+  openModifyEmailModal: string | undefined;
+  setOpenModifyEmailModal: React.Dispatch<
+    React.SetStateAction<string | undefined>
+  >;
+}
+
+export default function ModifyEmailModal({
+  openModifyEmailModal,
+  setOpenModifyEmailModal,
+}: ModifyEmailModalProps) {
+  const handleModifyUsername = () => {
+    const confirmResult = confirm('이메일을 변경하시겠습니까?');
+    if (!confirmResult) return;
+    alert('이메일이 변경되었습니다');
+    setOpenModifyEmailModal(undefined);
+  };
+
+  return (
+    <Modal
+      show={openModifyEmailModal === 'default'}
+      onClose={() => setOpenModifyEmailModal(undefined)}
+      className='fade-in-fast'
+      size='sm'
+    >
+      <Modal.Header>✉️ 이메일 변경</Modal.Header>
+      <Modal.Body className='p-3 pb-3'>
+        <div className='space-y-2'>
+          <div className='flex flex-col gap-2 mt-3 ml-2'>
+            <span className='w-[5.5rem]'>변경할 이메일</span>
+            <div className='flex items-center gap-2'>
+              <input
+                type='text'
+                placeholder='abc@gmail.com'
+                className='h-8 border w-[16rem] px-2 border-[#b4b4b4] text-sm rounded-[0.2rem] placeholder:text-gray-400'
+              />
+              <button className='text-white bg-[#3870e0] w-[5rem] h-8 rounded-[0.2rem] font-light focus:bg-[#3464c2] hover:bg-[#3464c2] box-shadow'>
+                중복확인
+              </button>
+            </div>
+          </div>
+        </div>
+      </Modal.Body>
+      <Modal.Footer className='mx-auto border-none'>
+        <button
+          onClick={handleModifyUsername}
+          className='text-white bg-[#3870e0] px-4 py-[0.4rem] rounded-[0.2rem] font-light focus:bg-[#3464c2] hover:bg-[#3464c2] box-shadow'
+        >
+          완료
+        </button>
+        <button
+          onClick={() => setOpenModifyEmailModal(undefined)}
+          className='bg-[#dddee0] px-4 py-[0.4rem] rounded-[0.2rem] font-light focus:bg-[#d0d1d3] hover:bg-[#d0d1d3] box-shadow'
+        >
+          취소
+        </button>
+      </Modal.Footer>
+    </Modal>
+  );
+}

--- a/app/mypage/components/modifyPasswordModal.tsx
+++ b/app/mypage/components/modifyPasswordModal.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import { Modal } from 'flowbite-react';
+
+interface ModifyPasswordModalProps {
+  openModifyPasswordModal: string | undefined;
+  setOpenModifyPasswordModal: React.Dispatch<
+    React.SetStateAction<string | undefined>
+  >;
+}
+
+export default function ModifyPasswordModal({
+  openModifyPasswordModal,
+  setOpenModifyPasswordModal,
+}: ModifyPasswordModalProps) {
+  const handleModifyPassword = () => {
+    const confirmResult = confirm('비밀번호를 변경하시겠습니까?');
+    if (!confirmResult) return;
+    alert('비밀번호가 변경되었습니다');
+    setOpenModifyPasswordModal(undefined);
+  };
+
+  return (
+    <Modal
+      show={openModifyPasswordModal === 'default'}
+      onClose={() => setOpenModifyPasswordModal(undefined)}
+      className='fade-in-fast'
+      size='md'
+    >
+      <Modal.Header>🔒 비밀번호 변경</Modal.Header>
+      <Modal.Body className='p-3 pb-3'>
+        <div className='space-y-2'>
+          <div className='flex flex-col gap-3 mt-3 ml-2'>
+            <div className='flex items-center'>
+              <span className='w-[9rem]'>현재 비밀번호</span>
+              <input
+                type='password'
+                className='h-8 border w-[14rem] px-2 tracking-widest rounded-[0.2rem] border-[#b4b4b4]'
+              />
+            </div>
+            <div className='flex items-center'>
+              <span className='w-[9rem]'>신규 비밀번호</span>
+              <input
+                type='password'
+                className='h-8 border w-[14rem] px-2 tracking-widest rounded-[0.2rem] border-[#b4b4b4]'
+              />
+            </div>
+            <div className='flex items-center'>
+              <span className='w-[9rem]'>신규 비밀번호 재입력</span>
+              <input
+                type='password'
+                className='h-8 border w-[14rem] px-2 tracking-widest rounded-[0.2rem] border-[#b4b4b4]'
+              />
+            </div>
+          </div>
+        </div>
+      </Modal.Body>
+      <Modal.Footer className='mx-auto border-none'>
+        <button
+          onClick={handleModifyPassword}
+          className='text-white bg-[#3870e0] px-4 py-[0.4rem] rounded-[0.2rem] font-light focus:bg-[#3464c2] hover:bg-[#3464c2] box-shadow'
+        >
+          완료
+        </button>
+        <button
+          onClick={() => setOpenModifyPasswordModal(undefined)}
+          className='bg-[#dddee0] px-4 py-[0.4rem] rounded-[0.2rem] font-light focus:bg-[#d0d1d3] hover:bg-[#d0d1d3] box-shadow'
+        >
+          취소
+        </button>
+      </Modal.Footer>
+    </Modal>
+  );
+}

--- a/app/mypage/components/modifyUsernameModal.tsx
+++ b/app/mypage/components/modifyUsernameModal.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import { Modal } from 'flowbite-react';
+
+interface ModifyUsernameModalProps {
+  openModifyUsernameModal: string | undefined;
+  setOpenModifyUsernameModal: React.Dispatch<
+    React.SetStateAction<string | undefined>
+  >;
+  username: string;
+}
+
+export default function ModifyUsernameModal({
+  openModifyUsernameModal,
+  setOpenModifyUsernameModal,
+  username,
+}: ModifyUsernameModalProps) {
+  const handleModifyUsername = () => {
+    const confirmResult = confirm('이름을 변경하시겠습니까?');
+    if (!confirmResult) return;
+    alert('이름이 변경되었습니다');
+    setOpenModifyUsernameModal(undefined);
+  };
+
+  return (
+    <Modal
+      show={openModifyUsernameModal === 'default'}
+      onClose={() => setOpenModifyUsernameModal(undefined)}
+      className='fade-in-fast'
+      size='md'
+    >
+      <Modal.Header>이름 수정</Modal.Header>
+      <Modal.Body className='p-3 pb-3'>
+        <div className='space-y-2'>
+          <div className='flex flex-col gap-3 mt-3 ml-2'>
+            <div className='flex items-center'>
+              <span className='w-[9rem]'>현재 이름</span>
+              <input
+                type='text'
+                placeholder={username}
+                className='h-8 border w-[14rem] px-2 border-[#b4b4b4] rounded-[0.2rem] bg-gray-100 text-sm'
+                disabled
+              />
+            </div>
+            <div className='flex items-center'>
+              <span className='w-[9rem]'>변경할 이름</span>
+              <input
+                type='text'
+                className='h-8 border w-[14rem] px-2 border-[#b4b4b4] rounded-[0.2rem] text-sm'
+              />
+            </div>
+          </div>
+        </div>
+      </Modal.Body>
+      <Modal.Footer className='mx-auto border-none'>
+        <button
+          onClick={handleModifyUsername}
+          className='text-white bg-[#3870e0] px-4 py-[0.4rem] rounded-[0.2rem] font-light focus:bg-[#3464c2] hover:bg-[#3464c2] box-shadow'
+        >
+          완료
+        </button>
+        <button
+          onClick={() => setOpenModifyUsernameModal(undefined)}
+          className='bg-[#dddee0] px-4 py-[0.4rem] rounded-[0.2rem] font-light focus:bg-[#d0d1d3] hover:bg-[#d0d1d3] box-shadow'
+        >
+          취소
+        </button>
+      </Modal.Footer>
+    </Modal>
+  );
+}

--- a/app/mypage/page.tsx
+++ b/app/mypage/page.tsx
@@ -7,14 +7,28 @@ import PostList from './PostList';
 import { useRouter } from 'next/navigation';
 import { initSelectedPostIds } from '../redux/features/selectedPostForDeleteSlice';
 import { useDispatch } from 'react-redux';
+import ModifyPasswordModal from './components/modifyPasswordModal';
+import ModifyUsernameModal from './components/modifyUsernameModal';
+import ModifyEmailModal from './components/modifyEmailModal';
 
 export default function Mypage() {
   const isAuth = useAppSelector((state) => state.authReducer.value.isAuth);
   const username = useAppSelector((state) => state.authReducer.value.username);
+  const email = useAppSelector((state) => state.authReducer.value.email);
   const uid = useAppSelector((state) => state.authReducer.value.uid);
   const selectedPostIds = useAppSelector(
     (state) => state.selectedPostForDeleteSlice.value.selectedPostIds
   );
+
+  const [openModifyPasswordModal, setOpenModifyPasswordModal] = useState<
+    string | undefined
+  >();
+  const [openModifyUsernameModal, setOpenModifyUsernameModal] = useState<
+    string | undefined
+  >();
+  const [openModifyEmailModal, setOpenModifyEmailModal] = useState<
+    string | undefined
+  >();
 
   const [isMypageReady, setIsMypageReady] = useState(false);
 
@@ -62,16 +76,52 @@ export default function Mypage() {
           <div className='flex items-center py-3 border-b'>
             <div className='w-44 text-sm'>비밀번호</div>
             <div className='w-80 font-bold'>********</div>
-            <button className='text-black border w-24 h-7 duration-200 hover:border-black'>
+            <button
+              onClick={() => setOpenModifyPasswordModal('default')}
+              className='text-black border w-24 h-7 duration-200 hover:border-black'
+            >
               비밀번호 변경
             </button>
+            {openModifyPasswordModal ? (
+              <ModifyPasswordModal
+                openModifyPasswordModal={openModifyPasswordModal}
+                setOpenModifyPasswordModal={setOpenModifyPasswordModal}
+              />
+            ) : null}
           </div>
           <div className='flex items-center py-3 border-b'>
             <div className='w-44 text-sm'>이름(실명)</div>
             <div className='w-80 font-bold'>{username}</div>
-            <button className='text-black border w-24 h-7 duration-200 hover:border-black'>
+            <button
+              onClick={() => setOpenModifyUsernameModal('default')}
+              className='text-black border w-24 h-7 duration-200 hover:border-black'
+            >
               이름 수정
             </button>
+            {openModifyUsernameModal ? (
+              <ModifyUsernameModal
+                openModifyUsernameModal={openModifyUsernameModal}
+                setOpenModifyUsernameModal={setOpenModifyUsernameModal}
+                username={username}
+              />
+            ) : null}
+          </div>
+          <div className='flex items-center py-3 border-b'>
+            <div className='w-44 text-sm'>이메일</div>
+            <div className='w-80 font-bold'>{email}</div>
+            <button
+              onClick={() => setOpenModifyEmailModal('default')}
+              className='text-black border w-24 h-7 duration-200 hover:border-black'
+            >
+              이메일 변경
+            </button>
+            {openModifyEmailModal ? (
+              <ModifyEmailModal
+                openModifyEmailModal={openModifyEmailModal}
+                setOpenModifyEmailModal={setOpenModifyEmailModal}
+                // email={email}
+              />
+            ) : null}
           </div>
         </div>
 

--- a/app/redux/features/authSlice.ts
+++ b/app/redux/features/authSlice.ts
@@ -2,6 +2,7 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
 interface UserInfo {
   username: string;
+  email: string;
   uid: string;
   isAdmin: boolean;
 }
@@ -18,6 +19,7 @@ const initialState = {
   value: {
     isAuth: false,
     username: '',
+    email: '',
     uid: '',
     isAdmin: false,
   } as AuthState,
@@ -32,6 +34,7 @@ export const auth = createSlice({
         value: {
           isAuth: true,
           username: action.payload.username,
+          email: action.payload.email,
           uid: action.payload.uid,
           isAdmin: action.payload.isAdmin,
         },


### PR DESCRIPTION
## 👀 이슈

resolve #26 

## 📌 개요

로그인된 유저에 대해서 마이페이지 내에
`이메일/비밀번호/이름`을 변경하는 기능을 추가하였습니다.

## 👩‍💻 작업 사항

- 마이페이지 내 `이메일/비밀번호/이름` 변경 기능 추가

## ✅ 참고 사항

- 마이페이지 내에 `이메일/비밀번호/이름` 변경 UI

https://github.com/bae-sisi/bss-client/assets/56868605/045bab91-ac22-4772-8bae-ca7612d84a41