### PR TITLE
[feat]: 행사 관련 페이지 컴포넌트 내에 auth 검증 기능 추가 (#30)

### DIFF
--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Loading from '@/app/loading';
+import { useAppSelector } from '@/app/redux/store';
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
@@ -11,23 +12,31 @@ const MarkdownPreview = dynamic(
 );
 
 export default function EventDetail() {
-  const [isExamPostReady, setIsExamPostReady] = useState(false);
+  const [isEventPostReady, setIsEventPostReady] = useState(false);
   const [isMarkdownPreviewReady, setIsMarkdownPreviewReady] = useState(false);
+
+  const uid = useAppSelector((state) => state.authReducer.value.uid);
+  const isAdmin = useAppSelector((state) => state.authReducer.value.isAdmin);
+
   const router = useRouter();
 
-  const handleDeleteExam = () => {
-    let userResponse = confirm('현재 행사 게시글을 삭제하시겠습니까?');
+  const handleDeleteEventPost = () => {
+    let userResponse = confirm('게시글을 삭제하시겠습니까?');
     if (!userResponse) return;
-    alert('게시글을 삭제하였습니다.');
+    alert('게시글을 삭제하였습니다');
     router.push('/events');
+  };
+
+  const handleEditEventPost = () => {
+    router.push(`/events/${'645f82d1dfc11e0020d07253'}/edit`);
   };
 
   useEffect(() => {
     setIsMarkdownPreviewReady(true);
-    setIsExamPostReady(true);
+    setIsEventPostReady(true);
   }, []);
 
-  return isExamPostReady && isMarkdownPreviewReady ? (
+  return isEventPostReady && isMarkdownPreviewReady ? (
     <div className='mt-6 mb-24 px-5 2lg:px-0 overflow-x-auto'>
       <div className='flex flex-col w-[60rem] mx-auto'>
         <div className='flex flex-col'>
@@ -100,25 +109,29 @@ _자세한 일정이 확정되면 추후 공지 예정_
               `}
             />
           </div>
-          <div>
+
+          {uid === '222' || isAdmin ? (
             <div className='flex gap-3 justify-end'>
-              <button
-                onClick={() => alert('개발 예정')}
-                className='flex gap-[0.375rem] items-center text-white bg-[#eba338] px-2 py-[0.4rem] rounded-[0.2rem] font-light focus:bg-[#dc9429] hover:bg-[#dc9429] box-shadow'
-              >
-                <svg
-                  xmlns='http://www.w3.org/2000/svg'
-                  height='20'
-                  viewBox='0 -960 960 960'
-                  width='20'
-                  fill='white'
+              {uid === '222' ? (
+                <button
+                  onClick={handleEditEventPost}
+                  className='flex gap-[0.375rem] items-center text-white bg-[#eba338] px-2 py-[0.4rem] rounded-[0.2rem] font-light focus:bg-[#dc9429] hover:bg-[#dc9429] box-shadow'
                 >
-                  <path d='M794-666 666-794l42-42q17-17 42.5-16.5T793-835l43 43q17 17 17 42t-17 42l-42 42Zm-42 42L248-120H120v-128l504-504 128 128Z' />
-                </svg>
-                게시글 수정
-              </button>
+                  <svg
+                    xmlns='http://www.w3.org/2000/svg'
+                    height='20'
+                    viewBox='0 -960 960 960'
+                    width='20'
+                    fill='white'
+                  >
+                    <path d='M794-666 666-794l42-42q17-17 42.5-16.5T793-835l43 43q17 17 17 42t-17 42l-42 42Zm-42 42L248-120H120v-128l504-504 128 128Z' />
+                  </svg>
+                  게시글 수정
+                </button>
+              ) : null}
+
               <button
-                onClick={handleDeleteExam}
+                onClick={handleDeleteEventPost}
                 className='flex gap-[0.375rem] items-center text-white bg-red-500 px-2 py-[0.4rem] rounded-[0.2rem] font-light focus:bg-[#e14343] hover:bg-[#e14343] box-shadow'
               >
                 <svg
@@ -133,7 +146,7 @@ _자세한 일정이 확정되면 추후 공지 예정_
                 게시글 삭제
               </button>
             </div>
-          </div>
+          ) : null}
         </div>
       </div>
     </div>

--- a/app/events/page.tsx
+++ b/app/events/page.tsx
@@ -1,19 +1,37 @@
-import React from 'react';
+'use client';
+
+import React, { useEffect, useState } from 'react';
 import Link from 'next/link';
 import EventList from './components/EventList';
+import { useAppSelector } from '../redux/store';
+import Loading from '../loading';
 
 export default function Events() {
-  return (
+  const isAuth = useAppSelector((state) => state.authReducer.value.isAuth);
+
+  const [isEventsReady, setIsEventsReady] = useState(false);
+
+  useEffect(() => {
+    setIsEventsReady(true);
+  }, []);
+
+  return isEventsReady ? (
     <div className='mt-2 px-5 2lg:px-0 overflow-x-auto'>
       <div className='flex flex-col w-[60rem] mx-auto'>
-        <p className='text-2xl font-semibold'>🎉 행사 목록</p>
-        <form className='mt-5 mb-4'>
+        <p className='flex items-center gap-3'>
+          <img
+            src='/images/icons/notice.png'
+            alt='logo'
+            style={{ width: '47.5px' }}
+          />
+          <span className='text-2xl font-semibold'>행사 목록</span>
+        </p>
+        <div className='mt-5 mb-4'>
           <div className='flex'>
             <div className='flex flex-col relative z-0 w-1/2 group'>
               <input
                 type='text'
                 name='floating_first_name'
-                id='floating_first_name'
                 className='block pl-7 pt-3 pb-[0.175rem] pr-0 w-full font-normal text-gray-900 bg-transparent border-0 border-b border-gray-400 appearance-none dark:text-white dark:border-gray-600 dark:focus:border-blue-500 focus:outline-none focus:ring-0 focus:border-blue-600 peer'
                 placeholder=' '
                 required
@@ -40,20 +58,22 @@ export default function Events() {
                 제목, 작성자로 검색
               </p>
             </div>
-            <div className='relative ml-auto mt-auto bottom-[-0.75rem]'>
-              <div className='flex justify-end mb-2'>
-                <div className='flex'>
-                  <Link
-                    href='events/register'
-                    className=' text-white bg-[#3870e0] px-4 py-[0.4rem] rounded-[0.2rem] font-light focus:bg-[#3464c2] hover:bg-[#3464c2] box-shadow'
-                  >
-                    등록하기
-                  </Link>
+            {isAuth ? (
+              <div className='relative ml-auto mt-auto bottom-[-0.75rem]'>
+                <div className='flex justify-end mb-2'>
+                  <div className='flex'>
+                    <Link
+                      href='events/register'
+                      className=' text-white bg-[#3870e0] px-4 py-[0.4rem] rounded-[0.2rem] font-light focus:bg-[#3464c2] hover:bg-[#3464c2] box-shadow'
+                    >
+                      등록하기
+                    </Link>
+                  </div>
                 </div>
               </div>
-            </div>
+            ) : null}
           </div>
-        </form>
+        </div>
 
         <section className='dark:bg-gray-900'>
           <div className='mx-auto w-full'>
@@ -179,5 +199,7 @@ export default function Events() {
         </section>
       </div>
     </div>
+  ) : (
+    <Loading />
   );
 }

--- a/app/events/register/page.tsx
+++ b/app/events/register/page.tsx
@@ -1,9 +1,10 @@
 'use client';
 
 import Loading from '@/app/loading';
+import { useAppSelector } from '@/app/redux/store';
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/navigation';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 const MDEditor = dynamic(
   () => import('@uiw/react-md-editor').then((mod) => mod.default),
@@ -11,28 +12,62 @@ const MDEditor = dynamic(
 );
 
 export default function RegisterEvent() {
+  const isAuth = useAppSelector((state) => state.authReducer.value.isAuth);
+
   const [isEditorReady, setIsEditorReady] = useState(false);
-  const [eventName, setEventName] = useState('');
+  const [title, setTitle] = useState('');
+  const [isTitleValidFail, setIsTitleValidFail] = useState(false);
   const [editorValue, setEditorValue] = useState('');
 
+  const titleRef = useRef<HTMLInputElement>(null);
+
   const router = useRouter();
+
+  useEffect(() => {
+    if (!isAuth) {
+      router.push('/login');
+      return;
+    }
+
+    setIsEditorReady(true);
+  }, [isAuth, router]);
 
   const handleEditorChange = useCallback((value?: string) => {
     setEditorValue(value || '');
   }, []);
 
-  const handleCancelContestRegister = () => {
-    let userResponse = confirm('행사 등록을 취소하시겠습니까?');
+  const handleTitleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setTitle(e.target.value);
+    setIsTitleValidFail(false);
+  };
+
+  const handleCancelEventRegister = () => {
+    let userResponse = confirm('행사 게시글 등록을 취소하시겠습니까?');
     if (!userResponse) return;
 
     router.push('/events');
   };
 
-  useEffect(() => {
-    setIsEditorReady(true);
-  }, []);
+  const handleRegisterEventPost = () => {
+    if (!title) {
+      alert('제목을 입력해 주세요');
+      window.scrollTo(0, 0);
+      titleRef.current?.focus();
+      setIsTitleValidFail(true);
+      return;
+    }
 
-  return (
+    if (!editorValue) {
+      alert('본문을 입력해 주세요');
+      window.scrollTo(0, 0);
+      return;
+    }
+
+    // 임시 게시글로 이동(작성 게시물로 이동해야 함)
+    router.push('/events/645f82d1dfc11e0020d07253');
+  };
+
+  return isEditorReady ? (
     <div className='mt-2 px-5 2lg:px-0 overflow-x-auto'>
       <div className='flex flex-col w-[60rem] mx-auto'>
         <p className='text-2xl font-semibold'>행사 등록</p>
@@ -42,47 +77,58 @@ export default function RegisterEvent() {
             <input
               type='text'
               name='floating_first_name'
-              id='floating_first_name'
-              className='block pt-3 pb-[0.175rem] pl-0 pr-0 w-full font-normal text-gray-900 bg-transparent border-0 border-b border-gray-400 appearance-none dark:text-white dark:border-gray-600 dark:focus:border-blue-500 focus:outline-none focus:ring-0 focus:border-blue-600 peer'
+              className={`block pt-3 pb-[0.175rem] pl-0 pr-0 w-full font-normal text-gray-900 bg-transparent border-0 border-b border-gray-400 appearance-none dark:text-white dark:border-gray-600 dark:focus:border-${
+                isTitleValidFail ? 'red' : 'blue'
+              }-500 focus:outline-none focus:ring-0 focus:border-${
+                isTitleValidFail ? 'red' : 'blue'
+              }-600 peer`}
               placeholder=' '
               required
-              value={eventName}
-              onChange={(e) => setEventName(e.target.value)}
+              value={title}
+              ref={titleRef}
+              onChange={handleTitleChange}
             />
             <label
               htmlFor='floating_first_name'
-              className='peer-focus:font-light absolute text-base left-[0.1rem] font-light text-gray-500 dark:text-gray-400 duration-300 transform -translate-y-5 scale-75 top-3 -z-10 origin-[0] peer-focus:left-[0.1rem] peer-focus:text-blue-600 peer-focus:dark:text-blue-500 peer-placeholder-shown:scale-100 peer-placeholder-shown:translate-y-0 peer-focus:scale-75 peer-focus:-translate-y-[1.25rem]'
+              className={`peer-focus:font-light absolute text-base left-[0.1rem] font-light text-${
+                isTitleValidFail ? 'red' : 'gray'
+              }-500 dark:text-gray-400 duration-300 transform -translate-y-5 scale-75 top-3 -z-10 origin-[0] peer-focus:left-[0.1rem] peer-focus:text-${
+                isTitleValidFail ? 'red' : 'blue'
+              }-600 peer-focus:dark:text-${
+                isTitleValidFail ? 'red' : 'blue'
+              }-500 peer-placeholder-shown:scale-100 peer-placeholder-shown:translate-y-0 peer-focus:scale-75 peer-focus:-translate-y-[1.25rem]`}
             >
               제목
             </label>
-            <p className='text-gray-500 text-xs tracking-widest font-light mt-1'>
+            <p
+              className={`text-${
+                isTitleValidFail ? 'red' : 'gray'
+              }-500 text-xs tracking-widest font-light mt-1`}
+            >
               제목을 입력해 주세요
             </p>
           </div>
         </div>
 
-        {isEditorReady ? (
-          <div className='w-full mx-auto overflow-auto'>
-            <MDEditor
-              value={editorValue}
-              onChange={handleEditorChange}
-              height={500}
-              className='md-editor'
-            />
-          </div>
-        ) : (
-          <Loading />
-        )}
+        <div className='w-full mx-auto overflow-auto'>
+          <MDEditor
+            autoFocus
+            value={editorValue}
+            onChange={handleEditorChange}
+            height={500}
+            className='md-editor'
+          />
+        </div>
 
         <div className='mt-8 pb-2 flex justify-end gap-3'>
           <button
-            onClick={handleCancelContestRegister}
+            onClick={handleCancelEventRegister}
             className=' px-4 py-[0.4rem] rounded-[0.2rem] font-light'
           >
             취소
           </button>
           <button
-            onClick={() => alert('개발 예정')}
+            onClick={handleRegisterEventPost}
             className=' text-white bg-[#3870e0] px-4 py-[0.4rem] rounded-[0.2rem] font-light focus:bg-[#3464c2] hover:bg-[#3464c2] box-shadow'
           >
             등록
@@ -90,5 +136,7 @@ export default function RegisterEvent() {
         </div>
       </div>
     </div>
+  ) : (
+    <Loading />
   );
 }

--- a/app/prof-infos/page.tsx
+++ b/app/prof-infos/page.tsx
@@ -5,7 +5,14 @@ export default function ProfInfos() {
   return (
     <div className='mt-2 px-5 2lg:px-0 overflow-x-auto'>
       <div className='flex flex-col w-[60rem] mx-auto'>
-        <p className='text-2xl font-semibold'>👨🏻‍🏫 교수 정보</p>
+        <p className='flex items-center gap-3'>
+          <img
+            src='/images/icons/person_flag.png'
+            alt='logo'
+            style={{ width: '47.5px' }}
+          />
+          <span className='text-2xl font-semibold'>교수 정보</span>
+        </p>
         <div className='mt-10 mb-10 grid grid-cols-2 gap-7'>
           <ProfInfo />
           <ProfInfo />


### PR DESCRIPTION
## 👀 이슈

resolve #30 

## 📌 개요

`행사` 관련 페이지 내에서 유저의 정보를 조회해야 하는 컴포넌트들에 대해
auth 정보를 검증할 수 있는 코드들을 추가하였습니다.

## 👩‍💻 작업 사항

- `행사` 관련 페이지 내에 auth 정보 검증 코드 추가
- `교수정보` 페이지 상단의 대표 이미지 아이콘 변경

## ✅ 참고 사항

없습니다
